### PR TITLE
Removal of closed servers.

### DIFF
--- a/servers.json
+++ b/servers.json
@@ -39,11 +39,7 @@
                 "ip": "d2s9.org",
                 "type": "PC"
         },
- 	{
-		"name": "mc.quiltanarchy.xyz",
-		"ip": "mc.quiltanarchy.xyz",
-		"type": "PC"
-	},
+ 	
  	{
 		"name": "5b5t.org",
 		"ip": "5b5t.org",
@@ -102,11 +98,6 @@
 	{
                 "name": "2b2t.com.ar",
                 "ip": "2b2t.com.ar",
-                "type": "PC"
-        },
-        {
-                "name": "2b2t.org.tr",
-                "ip": "2b2t.org.tr",
                 "type": "PC"
         },
 	{


### PR DESCRIPTION
Quilt Anarchy has been closed ever since **05-14-2025**
[](https://qzqc.eu/gtNVIpcv)
[](https://qzqc.eu/qhfYAogN)

2b2tr has been backdoored and every players log and passwords has been leaked, also the server haven't been online for almost a month.
[](https://qzqc.eu/zjpNcoJz)